### PR TITLE
Enforce 'update' branch for main merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
             8.0.x
 
       - name: Diagnose repo
+        shell: bash
         run: |
           dotnet --info
           echo "Lister filer og løsninger:"

--- a/.github/workflows/only-update-to-main
+++ b/.github/workflows/only-update-to-main
@@ -1,0 +1,18 @@
+name: Enforce Update Branch for Main Merges
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          echo "PR from: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "update" ]; then
+            echo "❌ Only 'update' branch can be merged into main!"
+            exit 1
+          fi


### PR DESCRIPTION
This workflow enforces that only the 'update' branch can be merged into the 'main' branch, adding a check step for pull requests.