### PR TITLE
Fix:Prevent back button login after logout by disabling cache

### DIFF
--- a/AOR/Controllers/LogInController.cs
+++ b/AOR/Controllers/LogInController.cs
@@ -140,12 +140,19 @@ public class LogInController : Controller
         }
 
         // Logg ut - støtter både GET og POST
-        [HttpPost, HttpGet]
-        public async Task<IActionResult> Logout()
-        {
-            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-            return RedirectToAction("Index");
-        }
+       [HttpPost, HttpGet]
+public async Task<IActionResult> Logout()
+{
+    await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+    // Make sure cache is cleared on logout response
+    Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+    Response.Headers["Pragma"] = "no-cache";
+    Response.Headers["Expires"] = "0";
+
+    return RedirectToAction("Index", "LogIn");
+}
+
     }
     }
 

--- a/AOR/Program.cs
+++ b/AOR/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using AOR.Data;
 using Microsoft.AspNetCore.Authentication.Cookies;
 
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services
@@ -31,6 +32,16 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
+
+// Disable caching so user cannot go back after logout
+app.Use(async (context, next) =>
+{
+    context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+    context.Response.Headers["Pragma"] = "no-cache";
+    context.Response.Headers["Expires"] = "0";
+    await next();
+});
+
 app.UseAuthentication();
 app.UseAuthorization();
 


### PR DESCRIPTION
- Added middleware in Program.cs to disable caching (no-cache, no-store, must-revalidate).
- Updated Logout action in LogInController to clear authentication cookie and prevent back navigation after logout.
- This fixes the issue where a user could press the browser back button to re-access a protected page after logging out.
