### PR TITLE
Zent/crew v2

### DIFF
--- a/AOR/Views/Crew/Index.cshtml
+++ b/AOR/Views/Crew/Index.cshtml
@@ -361,7 +361,7 @@
     /* Notification - responsive */
     .drawing-notification {
         position: absolute;
-        bottom: 95px;
+        bottom: 150px;
         left: 50%;
         transform: translateX(-50%);
         background: rgba(255, 255, 255, 0.95);
@@ -664,12 +664,10 @@
         const lat = latlng.lat.toFixed(5);
         const lng = latlng.lng.toFixed(5);
         
-        let actionsHtml = `<button class="point-btn remove" onclick="removePoint('${pointId}')" title="Remove">✕</button>`;
-    if (drawingMode !== 'powerline') {
-        actionsHtml = `
-            <button class="point-btn accept" onclick="confirmPoint('${pointId}')" title="Confirm">✓</button>
-            ${actionsHtml}
-        `;
+        // Only show action buttons for 'powerline', none for 'mast' or 'other'
+    let actionsHtml = '';
+    if (drawingMode === 'powerline') {
+        actionsHtml = `<button class="point-btn remove" onclick="removePoint('${pointId}')" title="Remove">✕</button>`;
     }
 
     pointItem.innerHTML = `


### PR DESCRIPTION
This pull request updates the point drawing logic in the `AOR/Views/Crew/Index.cshtml` file to improve user experience and enforce drawing rules for different modes. The main changes include restricting the number of points for certain modes, updating notification positioning, and adjusting point action buttons based on the drawing mode.

**Drawing mode restrictions and UI improvements:**

* Added logic to restrict users to only one point when drawing in `mast` or `other` modes, displaying an alert if they attempt to add more.
* Updated the confirmation logic to require at least two points for `powerline` mode and at least one point for `mast` or `other` modes, with appropriate alert messages.

**UI adjustments:**

* Changed the notification position by increasing the `bottom` offset to improve visibility.
* Modified the point action buttons so that only the remove button appears for `powerline` mode, and no action buttons are shown for `mast` or `other` modes.