### PR TITLE
Zent/crew v2

### DIFF
--- a/AOR/Views/Crew/Index.cshtml
+++ b/AOR/Views/Crew/Index.cshtml
@@ -361,7 +361,7 @@
     /* Notification - responsive */
     .drawing-notification {
         position: absolute;
-        bottom: 95px;
+        bottom: 150px;
         left: 50%;
         transform: translateX(-50%);
         background: rgba(255, 255, 255, 0.95);
@@ -664,12 +664,10 @@
         const lat = latlng.lat.toFixed(5);
         const lng = latlng.lng.toFixed(5);
         
-        let actionsHtml = `<button class="point-btn remove" onclick="removePoint('${pointId}')" title="Remove">✕</button>`;
-    if (drawingMode !== 'powerline') {
-        actionsHtml = `
-            <button class="point-btn accept" onclick="confirmPoint('${pointId}')" title="Confirm">✓</button>
-            ${actionsHtml}
-        `;
+        // Only show action buttons for 'powerline', none for 'mast' or 'other'
+    let actionsHtml = '';
+    if (drawingMode === 'powerline') {
+        actionsHtml = `<button class="point-btn remove" onclick="removePoint('${pointId}')" title="Remove">✕</button>`;
     }
 
     pointItem.innerHTML = `


### PR DESCRIPTION
This pull request introduces improvements to the drawing UI logic for the crew index page, specifically addressing how points are added and managed for different drawing modes (`powerline`, `mast`, and `other`). The changes enhance user experience by enforcing mode-specific constraints and updating UI feedback.

Drawing mode constraints and UI feedback:

* Only one point can be added for `mast` or `other` drawing modes; an alert is shown if the user tries to add more.
* Confirmation logic now requires at least two points for `powerline` and one point for `mast` or `other`, with mode-specific alert messages.

UI adjustments:

* The notification position was adjusted to display higher on the page for better visibility.
* Action buttons (confirm/remove) for points are now only shown when drawing a `powerline`; for `mast` and `other`, no action buttons are displayed.