### PR TITLE
Zent/crew v4

### DIFF
--- a/AOR/Views/Obstacle/DataForm.cshtml
+++ b/AOR/Views/Obstacle/DataForm.cshtml
@@ -230,8 +230,8 @@
     
     .draft-saved-notification {
         position: fixed;
-        top: 20px;
-        right: 20px;
+        top: 110px;
+        left: 50%;
         background: #10b981;
         color: white;
         padding: 12px 20px;
@@ -239,13 +239,14 @@
         box-shadow: 0 4px 12px rgba(0,0,0,0.15);
         z-index: 1000;
         opacity: 0;
-        transform: translateY(-20px);
+        transform: translate(-50%, -20px);
         transition: all 0.3s ease;
+        text-align: center;
     }
     
     .draft-saved-notification.show {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate(-50%, 0);
     }
 </style>
 

--- a/AOR/Views/Report/MyReports.cshtml
+++ b/AOR/Views/Report/MyReports.cshtml
@@ -409,6 +409,7 @@
             const formattedHeight = formatDraftHeight(data.ObstacleHeight, data.heightInput);
             const pointCount = deriveDraftPointCount(data);
 
+            // Do NOT add any type-specific fields; only show the common ones.
             const detailItems = [
                 { label: 'Height:', value: formattedHeight },
                 { label: 'Points:', value: pointCount.toString() },
@@ -416,23 +417,6 @@
                 { label: 'Status:', value: null, badge: 'DRAFT' },
                 { label: 'Type:', value: formattedType }
             ];
-
-            if (obstacleType === 'mast') {
-                if (data.MastType && data.MastType.trim() !== '') {
-                    detailItems.push({ label: 'Mast Type:', value: data.MastType });
-                }
-                if (typeof data.HasLighting !== 'undefined' && data.HasLighting !== '') {
-                    detailItems.push({ label: 'Has Lighting:', value: formatYesNo(data.HasLighting) });
-                }
-            } else if (obstacleType === 'powerline') {
-                if (data.WireCount && data.WireCount !== '') {
-                    detailItems.push({ label: 'Wire Count:', value: data.WireCount });
-                }
-            } else if (obstacleType === 'other') {
-                if (data.Category && data.Category.trim() !== '') {
-                    detailItems.push({ label: 'Category:', value: data.Category });
-                }
-            }
 
             detailItems.forEach(item => {
                 const wrapper = document.createElement('div');


### PR DESCRIPTION

**PR Summary**

- Added draft save/load UX to `DataForm.cshtml` and `MyReports.cshtml`, including localStorage integration, draft notification, and “Continue Editing” flow (Draft V1).
- Polished the draft cards and registration form: richer obstacle metadata, point/height formatting, and clear draft badges plus type badges for better at-a-glance info (Draft V2).
- Hardened draft persistence by canonicalizing incoming data, trimming/normalizing aliases, syncing hidden fields, and smoothing the draft load experience (Draft V3).
- Extended canonicalization to keep `displayName`/`draftTitle` in sync, refreshed draft stats, and ensured card generation works from the normalized payloads (Draft V4).
- Unified draft card detail fields across obstacle types and repositioned the “Draft saved” toast front-and-center for higher visibility (Draft V5).

