### PR TITLE
Endret slik at appen alltid starter på UiA

### DIFF
--- a/AOR/Views/Crew/Index.cshtml
+++ b/AOR/Views/Crew/Index.cshtml
@@ -605,9 +605,9 @@
     });
 
     function initializeMap() {
-        map = L.map('obstacle-map', {
-            center: showMyLocation(),
-            zoom: 6,
+       map = L.map('obstacle-map', {
+            center: [58.16376, 8.00183],
+            zoom: 16,
             zoomControl: true,
             touchZoom: true,
             scrollWheelZoom: true,


### PR DESCRIPTION
This pull request makes a minor update to the map initialization in `AOR/Views/Crew/Index.cshtml`. The map now starts at a fixed location and a higher zoom level, rather than centering on the user's location.

- Map Initialization:
  * Changed the `center` property to use static coordinates `[58.16376, 8.00183]` and increased the `zoom` level from 6 to 16 in the Leaflet map initialization.