### PR TITLE
Zent/crew v6

### DIFF
--- a/AOR/Views/Shared/_Layout.cshtml
+++ b/AOR/Views/Shared/_Layout.cshtml
@@ -78,6 +78,12 @@
             }
             <a class="navbar-brand d-none d-md-inline" asp-area="" asp-controller="@homeController" asp-action="@homeAction">AOR - Aviation Obstacle Registration</a>
             <a class="navbar-brand d-md-none" asp-area="" asp-controller="@homeController" asp-action="@homeAction">AOR</a>
+            @if (User?.Identity?.IsAuthenticated == true && User.IsInRole("Crew"))
+            {
+                <button id="last30DaysBtn" class="btn btn-outline-primary ms-3" onclick="toggleLast30Days()" style="display: none;">
+                    <i class="fa fa-calendar-days me-2"></i>Last 30 Days
+                </button>
+            }
         </div>
             <div class="d-sm-inline-flex justify-content-between">
                 <ul class="navbar-nav ms-auto fs-5">


### PR DESCRIPTION
This pull request adds a new UI feature for authenticated users with the "Crew" role. Specifically, it introduces a "Last 30 Days" button to the navigation bar, which is only visible to users in that role.

UI enhancements for role-based navigation:

* Added a "Last 30 Days" button to the navbar, visible only to authenticated users with the "Crew" role, and wired it to a `toggleLast30Days()` JavaScript function. (`AOR/Views/Shared/_Layout.cshtml`)